### PR TITLE
Repairs broken snap.ci link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Protractor Presentation in RevealJS and code materials demonstrating Protractor 
 You can see the slide deck at the [github-pages url for this repo: willbuck.github.io/midwestjs-2015-protractor](willbuck.github.io/midwestjs-2015-protractor) 
 
 Check out the last test run on SnapCi below!
-[![Build Status](https://snap-ci.com/willbuck/midwestjs-2015-protractor/branch/develop/build_image)](https://snap-ci.com/willbuck/revealjs-midwestjs-2015/branch/develop)
+[![Build Status](https://snap-ci.com/willbuck/midwestjs-2015-protractor/branch/develop/build_image)](https://snap-ci.com/willbuck/midwestjs-2015-protractor/branch/develop)
 
 ## Instructions
 I would recommend installing protractor, serve, and json-server globally, as all will be used in this project


### PR DESCRIPTION
I had it linked to the old repo name :_( after I changed it that must have broken
